### PR TITLE
Deploy ready auditor

### DIFF
--- a/awsAuditor.py
+++ b/awsAuditor.py
@@ -1,19 +1,29 @@
-from awsauditor.reportGenerator import ReportGenerator
+import datetime
+from reportGenerator import ReportGenerator
+
+"""
+Send month-to-date account management reports and individualized reports to specified individuals.
+"""
 
 
 def main():
-    # TODO Grab these from a commandline?
-    users = ['user1@email.com', 'email2@email.com' ]
-    recipients = ['manager@email.edu']
-    start = '2019-01-01'
-    end = '2019-01-24'  # Date is inclusive.
+    start = str(datetime.date.today().replace(day=1))
+    end = str(datetime.date.today())
+
+    manager_accounts = {'manager1@email.com': ['account1', 'account2'],
+                        'manager2@email.com': ['account2', 'account3']}
+
+    users = ['user1@email.com', 'user2@email.com']
 
     r = ReportGenerator(start_date=start, end_date=end)
 
-    r.send_management_report(recipients)
+    # Send account management reports
+    for manager, accounts in manager_accounts.items():
+        r.send_management_report(manager, accounts)
 
+    # Send individual reports
     for user in users:
-        r.send_individual_report(user, recipients)
+        r.send_individual_report(user)
 
 
 if __name__ == '__main__':

--- a/reportGenerator.py
+++ b/reportGenerator.py
@@ -39,7 +39,7 @@ class ReportGenerator:
         self.metrics = metrics or ['BlendedCost']
         self.client = boto3.client('ce', region_name='us-east-1')  # Region needs to be specified; Cost Explorer hosted here.
 
-        self.nums_to_aliases, self.aliases_to_nums = self.build_nums_to_aliases()
+        self.nums_to_aliases, self.aliases_to_nums = self.build_nums_to_aliases_dicts()
         self.account_nums = self.nums_to_aliases.keys()
 
     @staticmethod
@@ -63,9 +63,9 @@ class ReportGenerator:
         return str(next_day).split(' ')[0]  # return just the date component of the datetime.datetime object.
 
     @staticmethod
-    def build_nums_to_aliases():
+    def build_nums_to_aliases_dicts():
         """
-        Create a dictionary that pairs account numbers with their aliases.
+        Create two dictionaries that pair account numbers with their aliases and vice versa.
 
         Note that your results will be restricted by your boto3 permissions.
 


### PR DESCRIPTION
In preparation for deploying this as a lambda, I made some changes to when accounts are specified. In order to use the same ReportGenerator to generate reports across different accounts, accounts are now specified in function calls instead of at initialization.